### PR TITLE
Restrict concurrency when running ecr copy - Update copy-images.go

### DIFF
--- a/internal/deltastream/aws/copy-images.go
+++ b/internal/deltastream/aws/copy-images.go
@@ -97,7 +97,9 @@ func copyImages(ctx context.Context, cfg aws.Config, dp awsconfig.AWSDataplane) 
 		},
 	}
 
-	pool := pond.New(3, 1000)
+	// temporarily set the pool to single worker to avoid toomanyrequests ecr throttles
+	// limit queue to 10 image copy at a time
+	pool := pond.New(1, 10)
 	defer pool.StopAndWait()
 	group := pool.Group()
 


### PR DESCRIPTION
Example Throttle experienced with a stack in us-west-1

https://mgmt-grafana.stage.deltastream-internal.name/explore?schemaVersion=1&panes=%7B%226q2%22:%7B%22datasource%22:%22P8E80F9AEF21F6940%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22%7Bapp%3D%5C%22mgmt-server%5C%22%7D%20%7C%3D%20%60g1y1sy%60%20%7C%3D%20%60deploy%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22,%22hide%22:true%7D,%7B%22refId%22:%22B%22,%22expr%22:%22%7Bcw_import_name%3D%5C%22mgmt-playbooks-logs%5C%22,%20dataplaneid%3D%5C%22g1y1sy%5C%22,%20layer%3D%5C%22deploy%5C%22%7D%20%7C%3D%20%60kyverno:%20toomanyrequests%60%22,%22queryType%22:%22range%22,%22datasource%22:%7B%22type%22:%22loki%22,%22uid%22:%22P8E80F9AEF21F6940%22%7D,%22editorMode%22:%22builder%22,%22hide%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-12h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1
