### PR TITLE
Remove quote as it causes interpolation issue - Update cluster-config.go

### DIFF
--- a/internal/deltastream/aws/cluster-config.go
+++ b/internal/deltastream/aws/cluster-config.go
@@ -108,7 +108,6 @@ func updateClusterConfig(ctx context.Context, cfg aws.Config, dp awsconfig.AWSDa
 	clusterConfig := corev1.Secret{ObjectMeta: v1.ObjectMeta{Name: "cluster-settings", Namespace: "cluster-config"}}
 	_, err = controllerutil.CreateOrUpdate(ctx, kubeClient.Client, &clusterConfig, func() error {
 		clusterConfig.Data = map[string][]byte{
-			"quote":  []byte(`\"`),
 			"meshID": []byte("deltastream"),
 			// todo remove duplicate properties
 			"stack":             []byte(config.Stack.ValueString()),


### PR DESCRIPTION
Adding quote as a variable was causing a side-effect:

Issue: https://github.com/deltastreaminc/deltastreamv2/issues/936

seems not needed:
https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-substitution-of-numbers-and-booleans