### PR TITLE
Add double quotes for boolean config - Update cluster-config.go

### DIFF
--- a/internal/deltastream/aws/cluster-config.go
+++ b/internal/deltastream/aws/cluster-config.go
@@ -128,7 +128,7 @@ func updateClusterConfig(ctx context.Context, cfg aws.Config, dp awsconfig.AWSDa
 			"infraID":                          []byte(config.InfraId.ValueString()),
 			"infraName":                        []byte("ds-" + config.InfraId.ValueString()),
 			"infraType":                        []byte(config.InfraType.ValueString()),
-			"enableKoalaTracking":              []byte(enableKoalaTracking),
+			"enableKoalaTracking":              []byte(`"` + enableKoalaTracking + `"`),
 			"resourceID":                       []byte(config.EksResourceId.ValueString()),
 			"clusterName":                      []byte(*cluster.Name),
 			"cpuArchitecture":                  []byte(config.CpuArchitecture.ValueString()),


### PR DESCRIPTION
kustomize has issue with boolean value, need to add a quote to surround a boolean value.

Issue faced in recent run:



```
	False	ExternalSecret/deltastream/webapp-config dry-run failed: failed to 
create typed patch object (deltastream/webapp-config; external-secrets.io/v1beta1, Kind=ExternalSecret): 
.spec.target.template.data.PUBLIC_ENABLE_KOALA: expected string, got &value.valueUnstructured{Value:true}	

```