### PR TITLE
Pin flux version or else it just brings in latest in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,5 @@ download_assets:
 	helm repo update
 	cd internal/deltastream/aws/assets && helm pull cilium/cilium --version 1.16.1
 	cd internal/deltastream/aws/assets/flux-system && \
-		flux install --network-policy=false --export > gotk-components.yaml && \
+		flux install --version=v2.7.5 --network-policy=false --export > gotk-components.yaml && \
 		kustomize build . > flux.yaml.tmpl


### PR DESCRIPTION


Very latest flux v2.8.0 (released 17 hour ago) was causing few CRDs to become incompatible, the Makefile always bring latest ! silently causing issues.